### PR TITLE
Update gga.cc

### DIFF
--- a/HAL/src/drivers/positioning/gps/gga.cc
+++ b/HAL/src/drivers/positioning/gps/gga.cc
@@ -46,7 +46,6 @@ Gps::fillGGActx (int sect, const char* field)
  switch (sect)
  {
   case UTC:
-   *strchr (field, '.') = 0;
    nmea.utc = str10_to_word (field);
    break;
   case LONG:


### PR DESCRIPTION
*strchr is dangerous, possible null pointer, str10_to_word already checks for DOT